### PR TITLE
Add RTX 5090-32G entry to database

### DIFF
--- a/database.md
+++ b/database.md
@@ -14,5 +14,5 @@
 | RTX4090-24G        | 54.77 | 171.06 | 173.31 | 实体机，py310+torch241，archlinux系统  | [sd0ric4](https://github.com/sd0ric4)          |
 | Tesla P4-8G        | 4.96  | 4.80   | 2.82   | 实体机，py312+torch222                 | [kaiserKOA](https://github.com/kaiserKOA)      |
 | RTX4090D-48G       | 51.41 | 155.5  | 151.09 | docker容器云，仅供参考，py310+torch260 | [turning point](https://github.com/colstone)   |
-| NVIDIA RTX4090-24G | 46.48 | 162.35 | 162.39 | docker容器云（优云智算），py310.14+torch240+cu121，23.6GB显存 | [HuanLin](https://github.com/HuanLinOTO) |                                      |
+| NVIDIA RTX4090-24G | 46.48 | 162.35 | 162.39 | docker容器云（优云智算），py310.14+torch240+cu121，23.6GB显存 | [HuanLin](https://github.com/HuanLinOTO) |
 | RTX 5090-32G       | 69.16 | 224.41 | 236.03 | 智算云扉5090实例，仅供参考，py310+torch280 | [HuanLin](https://github.com/HuanLinOTO) |

--- a/database.md
+++ b/database.md
@@ -15,3 +15,4 @@
 | Tesla P4-8G        | 4.96  | 4.80   | 2.82   | 实体机，py312+torch222                 | [kaiserKOA](https://github.com/kaiserKOA)      |
 | RTX4090D-48G       | 51.41 | 155.5  | 151.09 | docker容器云，仅供参考，py310+torch260 | [turning point](https://github.com/colstone)   |
 | NVIDIA RTX4090-24G | 46.48 | 162.35 | 162.39 | docker容器云（优云智算），py310.14+torch240+cu121，23.6GB显存 | [HuanLin](https://github.com/HuanLinOTO) |                                      |
+| RTX 5090-32G       | 69.16 | 224.41 | 236.03 | 智算云扉5090实例，仅供参考，py310+torch280 | [HuanLin](https://github.com/HuanLinOTO) |


### PR DESCRIPTION
root@waas:~/SVCFusion# ~/1/.venv/bin/python -m SVCFusion.benchmark
本 BenchMark 脚本来自 zzc0721@github，仓库：https://github.com/zzc0721/torch-performance-test-data
测试设备: NVIDIA GeForce RTX 5090
显存大小: 31.4 GB

Python版本: 3.10.14 (main, May  6 2024, 19:42:50) [GCC 11.2.0]
PyTorch版本: 2.8.0+cu128

测试 FP32:
测试矩阵大小: 1024x1024
  性能: 47.84 TFLOPS
测试矩阵大小: 2048x2048
  性能: 69.16 TFLOPS
测试矩阵大小: 4096x4096
  性能: 65.03 TFLOPS
测试矩阵大小: 8192x8192
  性能: 66.34 TFLOPS
测试矩阵大小: 10240x10240
  性能: 65.22 TFLOPS

测试 FP16:
测试矩阵大小: 1024x1024
  性能: 142.29 TFLOPS
测试矩阵大小: 2048x2048
  性能: 174.04 TFLOPS
测试矩阵大小: 4096x4096
  性能: 218.79 TFLOPS
测试矩阵大小: 8192x8192
  性能: 224.41 TFLOPS
测试矩阵大小: 10240x10240
  性能: 219.10 TFLOPS

测试 BF16:
测试矩阵大小: 1024x1024
  性能: 93.60 TFLOPS
测试矩阵大小: 2048x2048
  性能: 173.87 TFLOPS
测试矩阵大小: 4096x4096
  性能: 183.71 TFLOPS
测试矩阵大小: 8192x8192
  性能: 236.03 TFLOPS
测试矩阵大小: 10240x10240
  性能: 235.27 TFLOPS

性能总结:
FP32 最大算力: 69.16 TFLOPS
FP16 最大算力: 224.41 TFLOPS
BF16 最大算力: 236.03 TFLOPS