### PR TITLE
ADD NVIDIA GeForce RTX 5070 Ti

### DIFF
--- a/database.md
+++ b/database.md
@@ -89,4 +89,4 @@
 | NVIDIA GeForce RTX 4090                      | 53.84  | 85.65  | 168.38  | 164.81  | 派欧云                                                                                   | [xiaoxi68](https://github.com/xiaoxi68)            |
 | NVIDIA GeForce RTX 3080 20G                  | 21.45  | 31.93  | 63.53   | 64.71   | 实体机                                                                                   | [2048Nemo](https://github.com/2048Nemo)            |
 | MTT S4000                                    | 15.61  | 40.64  | 76.75   | 78.18   | AutoDL                                                                                  | [kakaru](https://github.com/KakaruHayate)          |
-| NVIDIA GeForce RTX 5070 Ti | 33.08 | 50.45 | 98.70 | 99.06 | WSL2 | [dayi](https://github.com/rabbit-dayi) |
+| NVIDIA GeForce RTX 5070 Ti | 33.08 | 50.45 | 98.70 | 99.06 | 实体机; WSL2 + PyTorch 2.9.0+cu128 | [dayi](https://github.com/rabbit-dayi) |


### PR DESCRIPTION
```bash
测试设备: NVIDIA GeForce RTX 5070 Ti
显存大小: 15.9 GB

Python版本: 3.10.19 (main, Oct 28 2025, 12:10:48) [Clang 20.1.4 ]
PyTorch版本: 2.9.0+cu128

当前 TF32 设置:
/opt/bo/.venv/lib/python3.10/site-packages/torch/backends/cuda/__init__.py:131: UserWarning: Please use the new API settings to control TF32 behavior, such as torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g, torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS() will be deprecated after Pytorch 2.9. Please see https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices (Triggered internally at /pytorch/aten/src/ATen/Context.cpp:80.)
  return torch._C._get_cublas_allow_tf32()
  matmul.allow_tf32 = False
  cudnn.allow_tf32 = True

PyTorch 当前不支持 FP8 E4M3FN，跳过该项测试
  原因: "addmm_cuda" not implemented for 'Float8_e4m3fn'

[FP32] 已设置 TF32 = False

测试 FP32:
  完成 5 个尺寸测试

[TF32] 已设置 TF32 = True

测试 TF32:
  完成 5 个尺寸测试

测试 FP16:
  完成 5 个尺寸测试

测试 BF16:
  完成 5 个尺寸测试

============================================================
性能总结:
FP32         最大算力:   33.08 TFLOPS @ 8192x8192
TF32         最大算力:   50.45 TFLOPS @ 10240x10240
FP16         最大算力:   98.70 TFLOPS @ 10240x10240
BF16         最大算力:   99.06 TFLOPS @ 10240x10240
============================================================

============================================================
🎉 测试完成！

📊 性能数据摘要：
设备：NVIDIA GeForce RTX 5070 Ti
FP32: 33.08 TFLOPS | TF32: 50.45 TFLOPS | FP16: 98.70 TFLOPS | BF16: 99.06 TFLOPS

🔗 提交数据请点击以下链接：
https://github.com/zzc0721/torch-performance-test-data/issues/new?title=%E6%96%B0%E5%A2%9E%E6%80%A7%E8%83%BD%E6%95%B0%E6%8D%AE%EF%BC%9ANVIDIA%20GeForce%20RTX%205070%20Ti&body=%23%23%20%E8%AE%BE%E5%A4%87%E4%BF%A1%E6%81%AF%0A-%20%E8%AE%BE%E5%A4%87%E5%90%8D%E7%A7%B0%EF%BC%9ANVIDIA%20GeForce%20RTX%205070%20Ti%0A-%20Python%E7%89%88%E6%9C%AC%EF%BC%9Apy31019%0A-%20PyTorch%E7%89%88%E6%9C%AC%EF%BC%9Atorch290cu128%0A%0A%23%23%20%E6%80%A7%E8%83%BD%E6%95%B0%E6%8D%AE%0A%60%60%60%0A%7C%20NVIDIA%20GeForce%20RTX%205070%20Ti%20%7C%2033.08%20%7C%2050.45%20%7C%2098.70%20%7C%2099.06%20%7C%20%2A%2A%E8%AF%B7%E5%A1%AB%E5%86%99note%2A%2A%20%7C%20%2A%2A%E8%AF%B7%E5%A1%AB%E5%86%99contributor%2A%2A%20%7C%0A%60%60%60%0A%0A%0A%23%23%20%E8%AF%A6%E7%BB%86%E6%80%A7%E8%83%BD%E6%95%B0%E6%8D%AE%0A%60%60%60%0A%0AFP32%3A%0A%20%201024x1024%3A%2023.57%20TFLOPS%0A%20%202048x2048%3A%2029.16%20TFLOPS%0A%20%204096x4096%3A%2032.18%20TFLOPS%0A%20%208192x8192%3A%2033.08%20TFLOPS%0A%20%2010240x10240%3A%2031.59%20TFLOPS%0A%0ATF32%3A%0A%20%201024x1024%3A%2039.89%20TFLOPS%0A%20%202048x2048%3A%2044.66%20TFLOPS%0A%20%204096x4096%3A%2045.97%20TFLOPS%0A%20%208192x8192%3A%2049.48%20TFLOPS%0A%20%2010240x10240%3A%2050.45%20TFLOPS%0A%0AFP16%3A%0A%20%201024x1024%3A%2067.15%20TFLOPS%0A%20%202048x2048%3A%2085.49%20TFLOPS%0A%20%204096x4096%3A%2089.31%20TFLOPS%0A%20%208192x8192%3A%2094.46%20TFLOPS%0A%20%2010240x10240%3A%2098.70%20TFLOPS%0A%0ABF16%3A%0A%20%201024x1024%3A%2073.45%20TFLOPS%0A%20%202048x2048%3A%2088.53%20TFLOPS%0A%20%204096x4096%3A%2091.48%20TFLOPS%0A%20%208192x8192%3A%2094.56%20TFLOPS%0A%20%2010240x10240%3A%2099.06%20TFLOPS%0A%60%60%60%0A%0A%0A%23%23%20%E5%A1%AB%E5%86%99%E8%AF%B4%E6%98%8E%0A1.%20%2A%2Anote%E5%88%97%2A%2A%EF%BC%9A%E8%AF%B7%E5%A1%AB%E5%86%99%E6%B5%8B%E8%AF%95%E7%8E%AF%E5%A2%83%EF%BC%8C%E5%8C%85%E5%90%AB%E4%BB%A5%E4%B8%8B%E5%85%B3%E9%94%AE%E5%AD%97%E4%BC%9A%E8%87%AA%E5%8A%A8%E5%BD%92%E7%B1%BB%EF%BC%9A%0A%20%20%20-%20%60GCP%60%20%28GCP%E4%BA%91%E5%AE%9E%E4%BE%8B%29%0A%20%20%20-%20%60%E5%AE%9E%E4%BD%93%E6%9C%BA%60%20%28%E7%89%A9%E7%90%86%E6%9C%BA%E5%99%A8%29%0A%20%20%20-%20%60%E7%AC%94%E8%AE%B0%E6%9C%AC%60%20%28%E7%AC%94%E8%AE%B0%E6%9C%AC%E7%94%B5%E8%84%91%29%0A%20%20%20-%20%60docker%60%20%28Docker%E5%AE%B9%E5%99%A8%29%0A%20%20%20-%20%60%E4%BC%98%E4%BA%91%E6%99%BA%E7%AE%97%60%20%28%E4%BC%98%E4%BA%91%E6%99%BA%E7%AE%97%E5%B9%B3%E5%8F%B0%29%0A%20%20%20-%20%60%E6%99%BA%E7%AE%97%E4%BA%91%E6%89%89%60%20%28%E6%99%BA%E7%AE%97%E4%BA%91%E6%89%89%E5%B9%B3%E5%8F%B0%29%0A%0A2.%20%2A%2Acontributor%E5%88%97%2A%2A%EF%BC%9A%E6%A0%BC%E5%BC%8F%E4%B8%BA%20%60%5B%E7%94%A8%E6%88%B7%E5%90%8D%5D%28https%3A//github.com/%E7%94%A8%E6%88%B7%E5%90%8D%29%60%EF%BC%8C%E4%B8%8D%E5%A1%AB%E9%BB%98%E8%AE%A4%E4%BD%A0%E8%87%AA%E5%B7%B1%0A%0A%E6%84%9F%E8%B0%A2%E6%82%A8%E7%9A%84%E8%B4%A1%E7%8C%AE%EF%BC%81

============================================================
💡 提示：
1. 点击链接会自动填充设备信息和性能数据
2. 请在issue中填写note（测试环境）和contributor信息
3. 包含特定关键字的note将被自动归类
```